### PR TITLE
Fix possible memory leak in socket.cpp

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1358,6 +1358,7 @@ int Socket::KeepWriteIfConnected(int fd, int err, void* data) {
                                             RunClosure, thrd_func)) == 0) {
             return 0;
         } else {
+            delete thrd_func;  // release memory
             PLOG(ERROR) << "Fail to start bthread";
             // Fall through with non zero `err'
         }


### PR DESCRIPTION
When `bthread_start_background` fails to start, the closure `thrd_func` is not executed and released, which will cause a memory leak.
Fix: manually release when fail.